### PR TITLE
Avoid browser autofill to paste anything

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ node_modules
 lib/
 .DS_Store
 .idea/
+*.swp
+*.vim
 package-lock.json
 yarn.lock
 yarn-error.log

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import styled from 'styled-components';
 import {
   formatCardNumber,
   formatExpiry,
+  formatCvc,
   hasCardNumberReachedMaxLength,
   hasCVCReachedMaxLength,
   hasZipReachedMaxLength,
@@ -285,14 +286,12 @@ class CreditCardInput extends Component<Props, State> {
     const cardExpiry = e.target.value.split(' / ').join('/');
 
     this.cardExpiryField.value = formatExpiry(cardExpiry);
+    const value = this.cardExpiryField.value.split(' / ').join('/');
 
     this.setFieldValid();
 
-    const expiryError = isExpiryInvalid(
-      cardExpiry,
-      customTextLabels.expiryError
-    );
-    if (cardExpiry.length > 4) {
+    const expiryError = isExpiryInvalid(value, customTextLabels.expiryError);
+    if (value.length > 4) {
       if (expiryError) {
         this.setFieldInvalid(expiryError, 'cardExpiry');
       } else {
@@ -336,7 +335,9 @@ class CreditCardInput extends Component<Props, State> {
     { onChange }: { onChange?: ?Function } = { onChange: null }
   ) => (e: SyntheticInputEvent<*>) => {
     const { customTextLabels } = this.props;
-    const CVC = e.target.value;
+    const value = formatCvc(e.target.value);
+    this.cvcField.value = value;
+    const CVC = value;
     const CVCLength = CVC.length;
     const isZipFieldAvailable = this.props.enableZipInput && this.state.showZip;
     const cardType = payment.fns.cardType(this.state.cardNumber);
@@ -507,6 +508,7 @@ class CreditCardInput extends Component<Props, State> {
                 ref: cardNumberField => {
                   this.cardNumberField = cardNumberField;
                 },
+                maxlength: '19',
                 autoComplete: 'cc-number',
                 className: `credit-card-input ${inputClassName}`,
                 placeholder:
@@ -562,6 +564,7 @@ class CreditCardInput extends Component<Props, State> {
                 ref: cvcField => {
                   this.cvcField = cvcField;
                 },
+                maxlength: '5',
                 autoComplete: 'off',
                 className: `credit-card-input ${inputClassName}`,
                 placeholder: customTextLabels.cvcPlaceholder || 'CVC',
@@ -589,6 +592,7 @@ class CreditCardInput extends Component<Props, State> {
                 ref: zipField => {
                   this.zipField = zipField;
                 },
+                maxlength: '6',
                 className: `credit-card-input zip-input ${inputClassName}`,
                 pattern: '[0-9]*',
                 placeholder: customTextLabels.zipPlaceholder || 'Zip',

--- a/src/utils/formatter.js
+++ b/src/utils/formatter.js
@@ -118,7 +118,7 @@ export const hasZipReachedMaxLength = (type, currentValueLength) =>
   currentValueLength >= DEFAULT_ZIP_LENGTH;
 export const formatCardNumber = cardNumber => {
   const cardType = getCardTypeByValue(cardNumber);
-  if (!cardType) return cardNumber;
+  if (!cardType) return (cardNumber.match(/\d+/g) || []).join('');
   const { format } = cardType;
   if (format.global) {
     return cardNumber.match(format).join(' ');
@@ -132,13 +132,16 @@ export const formatCardNumber = cardNumber => {
   }
   return cardNumber;
 };
+export const formatCvc = cvc => {
+  return (cvc.match(/\d+/g) || []).join('');
+};
 export const formatExpiry = prevExpiry => {
   if (!prevExpiry) return null;
   let expiry = prevExpiry;
   if (/^[2-9]$/.test(expiry)) {
     expiry = `0${expiry}`;
   }
-  expiry = expiry.match(/(\d{1,2})/g);
+  expiry = expiry.match(/(\d{1,2})/g) || [];
   if (expiry.length === 1) {
     if (prevExpiry.includes('/')) {
       return expiry[0];
@@ -146,6 +149,10 @@ export const formatExpiry = prevExpiry => {
     if (/\d{2}/.test(expiry)) {
       return `${expiry[0]} / `;
     }
+  }
+  if (expiry.length > 2) {
+    const [, month, year] = expiry.join('').match(/^(\d{2}).*(\d{2})$/) || [];
+    return [month, year].join(' / ');
   }
   return expiry.join(' / ');
 };


### PR DESCRIPTION
This PR prevents the browser autofill to paste anything. See images below some issues we can face by using the browser autofill.

This PR will avoid this kind of issues to happen now on.


![Screen Shot 2019-04-16 at 20 51 06](https://user-images.githubusercontent.com/1886786/56251374-bb429600-6089-11e9-9ef7-22afc38b6445.png)

![Screen Shot 2019-04-16 at 20 51 19](https://user-images.githubusercontent.com/1886786/56251380-c0074a00-6089-11e9-8242-71d5cd7c322e.png)

![Screen Shot 2019-04-16 at 20 52 01](https://user-images.githubusercontent.com/1886786/56251385-c4336780-6089-11e9-9820-3469c71fecde.png)
