### PR TITLE
Enhance month-year input

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -182,6 +182,10 @@ class CreditCardInput extends Component<Props, State> {
     });
   };
 
+  isMonthDashKey = ({ key, target: { value } } = {}) => {
+    return !value.match(/[/-]/) && /^[/-]$/.test(key);
+  };
+
   checkIsNumeric = (e: any) => {
     if (!/^\d*$/.test(e.key)) {
       e.preventDefault();
@@ -290,9 +294,8 @@ class CreditCardInput extends Component<Props, State> {
     { onChange }: { onChange?: ?Function } = { onChange: null }
   ) => (e: SyntheticInputEvent<*>) => {
     const { customTextLabels } = this.props;
-    const cardExpiry = e.target.value.split(' / ').join('/');
 
-    this.cardExpiryField.value = formatExpiry(cardExpiry);
+    this.cardExpiryField.value = formatExpiry(e);
     const value = this.cardExpiryField.value.split(' / ').join('/');
 
     this.setFieldValid();
@@ -313,7 +316,11 @@ class CreditCardInput extends Component<Props, State> {
 
   handleCardExpiryKeyPress = (e: any) => {
     const value = e.target.value;
-    this.checkIsNumeric(e);
+
+    if (!this.isMonthDashKey(e)) {
+      this.checkIsNumeric(e);
+    }
+
     if (value && !isHighlighted()) {
       const valueLength = value.split(' / ').join('').length;
       if (valueLength >= 4) {

--- a/src/utils/formatter.js
+++ b/src/utils/formatter.js
@@ -135,15 +135,28 @@ export const formatCardNumber = cardNumber => {
 export const formatCvc = cvc => {
   return (cvc.match(/\d+/g) || []).join('');
 };
-export const formatExpiry = prevExpiry => {
+export const formatExpiry = event => {
+  const eventData = event.nativeEvent && event.nativeEvent.data;
+  const prevExpiry = event.target.value.split(' / ').join('/');
+
   if (!prevExpiry) return null;
   let expiry = prevExpiry;
   if (/^[2-9]$/.test(expiry)) {
     expiry = `0${expiry}`;
   }
+
+  if (prevExpiry.length === 2 && +prevExpiry > 12) {
+    const [head, ...tail] = prevExpiry;
+    expiry = `0${head}/${tail.join('')}`;
+  }
+
+  if (/^1[/-]$/.test(expiry)) {
+    return `01 / `;
+  }
+
   expiry = expiry.match(/(\d{1,2})/g) || [];
   if (expiry.length === 1) {
-    if (prevExpiry.includes('/')) {
+    if (!eventData && prevExpiry.includes('/')) {
       return expiry[0];
     }
     if (/\d{2}/.test(expiry)) {


### PR DESCRIPTION
This PR improves a bit how the user fills out the month input. For instance, that improvement does not allow to type `15` as a month. Also, it helps the user auto advancing faster by typing the dash key.

As it is today, it shows an error message, that's fine too, but why not improving a bit to decrease the chance this kind of error message appear?

![image](https://user-images.githubusercontent.com/1886786/56303602-a4945180-6112-11e9-8651-18c47d6102c2.png)

-------

There's an [e-commerce](https://www.warbyparker.com/checkout/step/information) that does it already. See link below in case wanna play with it:
- https://www.warbyparker.com

![image](https://user-images.githubusercontent.com/1886786/56304226-0acda400-6114-11e9-883c-d220fc7efa81.png)

