### PR TITLE
Clean up rollup config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,20 +8,17 @@ export default {
     format: 'umd',
     globals: {
       react: 'React',
-      'react-dom': 'ReactDOM',
       payment: 'payment',
       'credit-card-type': 'creditCardType',
-      'styled-components': 'styled',
-      'is-valid-zip': 'isValidZip'
+      'styled-components': 'styled'
     }
   },
+  sourcemap: true,
   external: [
     'react',
-    'react-dom',
     'credit-card-type',
     'payment',
-    'styled-components',
-    'is-valid-zip'
+    'styled-components'
   ],
   plugins: [
     babel({


### PR DESCRIPTION
This PR cleans up a bit the rollup config.
- `react-dom`: it's not being used inside the folder `src`, so no need add it.
- `is-valid-zip`: there's nothing importing that library inside the folder `src`, for some reason `isValidZip` was renamed to `isZipValid` awhile back. Even though, there's no need to add it too.

Also, it adds source map, it helps a lot while debugging. 