### PR TITLE
Add aria-label to inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "flow": "flow",
     "prettier": "prettier --config .prettierrc --write \"src/**/*.js\"",
     "prettier:list-diff": "prettier --config .prettierrc --list-different 'src/**/*.js'",
-    "storybook": "start-storybook -p 9001 -c .storybook",
+    "storybook": "start-storybook -p 9567 -c .storybook",
     "storybook:build": "build-storybook -c .storybook -o docs/",
     "test": "npm run lint && npm run flow && npm run prettier:list-diff"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -533,6 +533,8 @@ class CreditCardInput extends Component<Props, State> {
                 placeholder:
                   customTextLabels.cardNumberPlaceholder || 'Card number',
                 type: 'tel',
+                'aria-label':
+                  customTextLabels.cardNumberPlaceholder || 'Card number',
                 ...cardNumberInputProps,
                 onBlur: this.handleCardNumberBlur(),
                 onChange: this.handleCardNumberChange(),
@@ -560,6 +562,7 @@ class CreditCardInput extends Component<Props, State> {
                 autoComplete: 'cc-exp',
                 className: `credit-card-input ${inputClassName}`,
                 placeholder: customTextLabels.expiryPlaceholder || 'MM/YY',
+                'aria-label': customTextLabels.expiryPlaceholder || 'MM/YY',
                 type: 'tel',
                 ...cardExpiryInputProps,
                 onBlur: this.handleCardExpiryBlur(),
@@ -589,6 +592,7 @@ class CreditCardInput extends Component<Props, State> {
                 autoComplete: 'off',
                 className: `credit-card-input ${inputClassName}`,
                 placeholder: customTextLabels.cvcPlaceholder || 'CVC',
+                'aria-label': customTextLabels.cvcPlaceholder || 'CVC',
                 type: 'tel',
                 ...cardCVCInputProps,
                 onBlur: this.handleCardCVCBlur(),
@@ -618,6 +622,7 @@ class CreditCardInput extends Component<Props, State> {
                 className: `credit-card-input zip-input ${inputClassName}`,
                 pattern: '[0-9]*',
                 placeholder: customTextLabels.zipPlaceholder || 'Zip',
+                'aria-label': customTextLabels.zipPlaceholder || 'Zip',
                 type: 'text',
                 ...cardZipInputProps,
                 onBlur: this.handleCardZipBlur(),


### PR DESCRIPTION
Currently, there's no aria-label listed on the inputs. For the improved accessibility, I add the aria-label to all of the inputs. For now, we just reuse the placeholder but in the future it might make sense for the labels to be customizable.